### PR TITLE
Troubleshooting on remotes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 
 * Set minimal R version required to 3.1.0.
 
+* `expect_doppelganger()` gains a `verbose` argument to print the
+  SVG files for failed cases while testing. This is useful to debug
+  failures on remotes.
+
 
 # vdiffr 0.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,12 @@
   SVG files for failed cases while testing. This is useful to debug
   failures on remotes.
 
+* When tests are run by `R CMD check`, failures are now recorded in a
+  log file called `vdiffr.fail`. This file will show up in the Travis
+  log and can be retrieved from artifacts on Appveyor. It includes the
+  SVG files for failed cases, which is useful to debug failures on
+  remotes.
+
 
 # vdiffr 0.1.1
 

--- a/R/testthat-reporter.R
+++ b/R/testthat-reporter.R
@@ -65,11 +65,12 @@ vdiffrReporter <-
 
       add_result = function(context, test, result) {
         cat(single_letter_summary(result))
+
+        case <- attr(result, "vdiffr_case")
         if (expectation_error(result)) {
           self$failure <- result
         }
         if (is_verbose(result)) {
-          case <- attr(result, "vdiffr_case")
           self$verbose_cases <- c(self$verbose_cases, list(case))
         }
       },

--- a/R/testthat-reporter.R
+++ b/R/testthat-reporter.R
@@ -54,8 +54,11 @@ vdiffrReporter <-
   R6::R6Class("vdiffrReporter", inherit = testthat::Reporter,
     public = list(
       failure = NULL,
+      verbose_cases = list(),
+      pkg_path = NULL,
 
       initialize = function(pkg_path) {
+        self$pkg_path <- pkg_path
         collecter <- casesCollecter$new(pkg_path)
         set_active_collecter(collecter)
       },
@@ -65,20 +68,43 @@ vdiffrReporter <-
         if (expectation_error(result)) {
           self$failure <- result
         }
+        if (is_verbose(result)) {
+          case <- attr(result, "vdiffr_case")
+          self$verbose_cases <- c(self$verbose_cases, list(case))
+        }
       },
 
       end_reporter = function() {
-        cat("\n")
+        meow()
+
         if (!is.null(self$failure)) {
-          stop(call. = FALSE,
-            "while collecting vdiffr cases. Last error:\n",
-            "     test: `", self$failure$test, "`\n",
-            "  message: `", self$failure$message, "`"
+          abort(glue(
+            "while collecting vdiffr cases. Last error:
+             test: { self$failure$test }
+             message: { self$failure$message }"
+          ))
+        }
+        if (length(self$verbose_cases)) {
+          meow(
+            glue(
+              "====================
+               vdiffr failing cases
+               ===================="
+            ),
+            map(self$verbose_cases, svg_files_lines, self$pkg_path),
+            (
+              "===================="
+            )
           )
         }
       }
     )
   )
+
+is_verbose <- function(x) {
+  case <- attr(x, "vdiffr_case")
+  !is_null(case) && case$verbose
+}
 
 expectation_type <- function(exp) {
   stopifnot(inherits(exp, "expectation"))

--- a/R/testthat-ui.R
+++ b/R/testthat-ui.R
@@ -26,6 +26,9 @@
 #' @param user_fonts Passed to \code{\link[svglite]{svglite}()} to
 #'   make sure SVG are reproducible. Defaults to Liberation fonts for
 #'   standard families and Symbola font for symbols.
+#' @param verbose If \code{TRUE}, the contents of the SVG files for
+#'   the comparison plots are printed during testthat checks. This is
+#'   useful to investigate errors when testing remotely.
 #' @export
 #' @examples
 #' ver <- gdtools::version_freetype()
@@ -41,7 +44,7 @@
 #'   expect_doppelganger("disp-histogram-ggplot", disp_hist_ggplot)
 #' }
 expect_doppelganger <- function(title, fig, path = NULL, ...,
-                                user_fonts = NULL) {
+                                user_fonts = NULL, verbose = FALSE) {
   if (old_freetype()) {
     ver <- gdtools::version_freetype()
     msg <- paste("vdiffr requires FreeType >= 2.6.0. Current version:", ver)
@@ -64,7 +67,8 @@ expect_doppelganger <- function(title, fig, path = NULL, ...,
   case <- case(list(
     name = fig_name,
     path = path,
-    testcase = testcase
+    testcase = testcase,
+    verbose = verbose
   ))
 
   if (file.exists(path)) {
@@ -73,7 +77,7 @@ expect_doppelganger <- function(title, fig, path = NULL, ...,
     case <- new_case(case)
     maybe_collect_case(case)
     msg <- paste0("Figure not generated yet: ", fig_name, ".svg")
-    exp <- expectation_new(msg)
+    exp <- expectation_new(msg, case)
   }
 
   signal_expectation(exp)
@@ -92,33 +96,33 @@ compare_figs <- function(case) {
   equal <- compare_files(case$testcase, normalizePath(case$path))
 
   if (equal) {
-    exp <- expectation_match("TRUE")
     case <- success_case(case)
     maybe_collect_case(case)
+    exp <- expectation_match("TRUE", case)
   } else {
-    msg <- paste0("Figures don't match: ", case$name, ".svg\n")
-    exp <- expectation_mismatch(msg)
     case <- mismatch_case(case)
     maybe_collect_case(case)
+    msg <- paste0("Figures don't match: ", case$name, ".svg\n")
+    exp <- expectation_mismatch(msg, case)
   }
 
   exp
 }
 
-expectation_new <- function(msg) {
-  x <- testthat::expectation("skip", msg)
-  classes <- c(class(x), "vdiffr_new")
-  structure(x, class = classes)
+expectation_new <- function(msg, case) {
+  exp <- testthat::expectation("skip", msg)
+  classes <- c(class(exp), "vdiffr_new")
+  set_attrs(exp, class = classes, vdiffr_case = case)
 }
-expectation_mismatch <- function(msg) {
+expectation_mismatch <- function(msg, case) {
   exp <- testthat::expectation("failure", msg)
   classes <- c(class(exp), "vdiffr_mismatch")
-  structure(exp, class = classes)
+  set_attrs(exp, class = classes, vdiffr_case = case)
 }
-expectation_match <- function(msg) {
+expectation_match <- function(msg, case) {
   exp <- testthat::expectation("success", msg)
   classes <- c(class(exp), "vdiffr_match")
-  structure(exp, class = classes)
+  set_attrs(exp, class = classes, vdiffr_case = case)
 }
 
 # From testthat

--- a/R/testthat-ui.R
+++ b/R/testthat-ui.R
@@ -102,8 +102,11 @@ compare_figs <- function(case) {
   } else {
     case <- mismatch_case(case)
     maybe_collect_case(case)
+
     msg <- paste0("Figures don't match: ", case$name, ".svg\n")
     exp <- expectation_mismatch(msg, case)
+
+    push_log(case)
   }
 
   exp

--- a/R/testthat-ui.R
+++ b/R/testthat-ui.R
@@ -29,6 +29,11 @@
 #' @param verbose If \code{TRUE}, the contents of the SVG files for
 #'   the comparison plots are printed during testthat checks. This is
 #'   useful to investigate errors when testing remotely.
+#'
+#'   Note that it is not possible to print the original SVG during
+#'   interactive use. This is because there is no way of figuring out
+#'   in which directory this SVG lives. Consequently, only the test
+#'   case is printed.
 #' @export
 #' @examples
 #' ver <- gdtools::version_freetype()
@@ -76,6 +81,7 @@ expect_doppelganger <- function(title, fig, path = NULL, ...,
   } else {
     case <- new_case(case)
     maybe_collect_case(case)
+    maybe_print_svgs(case)
     msg <- paste0("Figure not generated yet: ", fig_name, ".svg")
     exp <- expectation_new(msg, case)
   }
@@ -110,6 +116,14 @@ compare_figs <- function(case) {
   }
 
   exp
+}
+
+# Print only if we're not collecting. The testthat reporter prints
+# verbose cases at a later point.
+maybe_print_svgs <- function(case, pkg_path = NULL) {
+  if (case$verbose && is_null(active_collecter())) {
+    meow(svg_files_lines(case, pkg_path))
+  }
 }
 
 expectation_new <- function(msg, case) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -97,13 +97,14 @@ svg_files_lines <- function(case, pkg_path = NULL) {
 
   chr_lines(
     glue(
-      ">>> Failed doppelganger: { case$name } <<<
-       >>> Original SVG:"
+      ">> Failed doppelganger: { case$name }
+       > Original SVG:"
     ),
     readLines(original_path),
-    ">>> Testcase SVG:",
+    "",
+    "> Testcase SVG:",
     readLines(case$testcase),
-    "<<<"
+    ""
   )
 }
 from_test_dir <- function(pkg_path, path) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -71,3 +71,29 @@ dir.exists <- function(paths) {
 dir_exists <- function(path) {
   !identical(path, "") && file.exists(paste0(path, .Platform$file.sep))
 }
+
+chr_lines <- function(..., trailing = FALSE) {
+  lines <- paste(chr(...), collapse = "\n")
+  if (trailing) {
+    lines <- paste0(lines, "\n")
+  }
+  lines
+}
+meow <- function(...) {
+  cat(chr_lines(..., trailing = TRUE))
+}
+cxn_meow <- function(.cxn, ...) {
+  cat(chr_lines(..., trailing = TRUE), file = .cxn)
+}
+
+svg_files_lines <- function(case, pkg_path) {
+  name <- case$name
+
+  chr_lines(
+    glue(">>> { name } - original <<<"),
+    readLines(from_test_dir(pkg_path, case$path)),
+    glue(">>> { name } - failing <<<"),
+    readLines(case$testcase)
+  )
+}
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -95,13 +95,22 @@ svg_files_lines <- function(case, pkg_path = NULL) {
     original_path <- from_test_dir(pkg_path, case$path)
   }
 
-  chr_lines(
-    glue(
-      ">> Failed doppelganger: { case$name }
-       > Original SVG:"
-    ),
-    readLines(original_path),
-    "",
+  # If called from interactive use, we most likely can't figure out
+  # where the original SVG lives (most likely in a subdirectory within
+  # the `figs` folder) so we don't print it.
+  if (file.exists(original_path)) {
+    original_lines <- chr_lines(
+      "> Original SVG:",
+      readLines(original_path),
+      ""
+    )
+  } else {
+    original_lines <- ""
+  }
+
+  lines <- chr_lines(
+    glue(">> Failed doppelganger: { case$name }"),
+    original_lines,
     "> Testcase SVG:",
     readLines(case$testcase),
     ""

--- a/R/utils.R
+++ b/R/utils.R
@@ -116,9 +116,26 @@ push_log <- function(case) {
   }
 
   log_path <- file.path("..", "vdiffr.fail")
+  log_exists <- file.exists(log_path)
+
   file <- file(log_path, "a")
   on.exit(close(file))
 
+  if (!log_exists) {
+    cxn_meow(file, glue(
+      "R environment:
+       - vdiffr: { utils::packageVersion('vdiffr') }
+       - gdtools: { utils::packageVersion('gdtools') }
+       - svglite: { utils::packageVersion('svglite') }
+
+       System environment:
+       - Fontconfig: { gdtools::version_fontconfig() }
+       - FreeType: { gdtools::version_freetype() }
+       - Cairo: { gdtools::version_cairo() }
+
+      "
+    ))
+  }
   cxn_meow(file, svg_files_lines(case))
 
   invisible(TRUE)

--- a/man/expect_doppelganger.Rd
+++ b/man/expect_doppelganger.Rd
@@ -30,8 +30,13 @@ make sure SVG are reproducible. Defaults to Liberation fonts for
 standard families and Symbola font for symbols.}
 
 \item{verbose}{If \code{TRUE}, the contents of the SVG files for
-the comparison plots are printed during testthat checks. This is
-useful to investigate errors when testing remotely.}
+  the comparison plots are printed during testthat checks. This is
+  useful to investigate errors when testing remotely.
+
+  Note that it is not possible to print the original SVG during
+  interactive use. This is because there is no way of figuring out
+  in which directory this SVG lives. Consequently, only the test
+  case is printed.}
 }
 \description{
 If the test has never been validated yet, the test is skipped. If

--- a/man/expect_doppelganger.Rd
+++ b/man/expect_doppelganger.Rd
@@ -4,7 +4,8 @@
 \alias{expect_doppelganger}
 \title{Does a figure look like its expected output?}
 \usage{
-expect_doppelganger(title, fig, path = NULL, ..., user_fonts = NULL)
+expect_doppelganger(title, fig, path = NULL, ..., user_fonts = NULL,
+  verbose = FALSE)
 }
 \arguments{
 \item{title}{The figure title is used for creating the figure file
@@ -27,6 +28,10 @@ comparison.}
 \item{user_fonts}{Passed to \code{\link[svglite]{svglite}()} to
 make sure SVG are reproducible. Defaults to Liberation fonts for
 standard families and Symbola font for symbols.}
+
+\item{verbose}{If \code{TRUE}, the contents of the SVG files for
+the comparison plots are printed during testthat checks. This is
+useful to investigate errors when testing remotely.}
 }
 \description{
 If the test has never been validated yet, the test is skipped. If

--- a/tests/testthat/helper-mock.R
+++ b/tests/testthat/helper-mock.R
@@ -1,10 +1,16 @@
 
 create_mock_pkg <- function(pkg = "mock-pkg") {
   dir <- tempfile()
-  dir.create(dir)
 
-  file.copy(paste0(pkg, "/"), dir, recursive = TRUE)
-  file.path(dir, pkg)
+  dir.create(dir, recursive = TRUE)
+  file.copy(pkg, dir, recursive = TRUE)
+
+  # Enable `R CMD check` logging
+  from <- file.path(dir, pkg)
+  to <- paste0(from, ".Rcheck")
+  file.rename(from, to)
+
+  to
 }
 
 subset_results <- function(results, file, test) {
@@ -23,6 +29,9 @@ skip_old_freetype <- function() {
   }
 }
 
+is_checking <- function() {
+  nzchar(Sys.getenv("R_TESTS"))
+}
 
 
 stack <- rev(rlang::ctxt_stack())

--- a/tests/testthat/mock-pkg/tests/testthat/test-failed.R
+++ b/tests/testthat/mock-pkg/tests/testthat/test-failed.R
@@ -16,3 +16,7 @@ test_that("New plots work are collected", {
 test_that("Duplicated expectations issue a warning", {
   expect_doppelganger("myplot", p1_fail, "")
 })
+
+test_that("SVGs of failing cases are printed when `verbose` is TRUE", {
+  expect_doppelganger("myplot", p1_fail, "", verbose = TRUE)
+})

--- a/tests/testthat/test-expectations.R
+++ b/tests/testthat/test-expectations.R
@@ -27,5 +27,5 @@ test_that("Doppelgangers pass", {
 
 test_that("Verbose outputs svg files", {
   output <- mock_cases_outputs$output
-  expect_true(grepl("myplot - original <<<\n<\\?xml version", output))
+  expect_true(grepl(">>> Failed doppelganger: myplot", output))
 })

--- a/tests/testthat/test-expectations.R
+++ b/tests/testthat/test-expectations.R
@@ -24,8 +24,3 @@ test_that("Doppelgangers pass", {
   expect_is(ggplot_result, "expectation_success")
   expect_is(base_result, "expectation_success")
 })
-
-test_that("Verbose outputs svg files", {
-  output <- mock_cases_outputs$output
-  expect_true(grepl(">>> Failed doppelganger: myplot", output))
-})

--- a/tests/testthat/test-expectations.R
+++ b/tests/testthat/test-expectations.R
@@ -24,3 +24,8 @@ test_that("Doppelgangers pass", {
   expect_is(ggplot_result, "expectation_success")
   expect_is(base_result, "expectation_success")
 })
+
+test_that("Verbose outputs svg files", {
+  output <- mock_cases_outputs$output
+  expect_true(grepl("myplot - original <<<\n<\\?xml version", output))
+})

--- a/tests/testthat/test-mismatch.R
+++ b/tests/testthat/test-mismatch.R
@@ -1,0 +1,13 @@
+context("mismatch")
+
+test_that("failures are pushed to log file", {
+  if (!is_checking()) {
+    return("Skipping R CMD check tests")
+  }
+
+  log <- readLines(file.path(mock_pkg_dir, "tests", "vdiffr.fail"))
+
+  n_logged <- length(grep(">>> Failed doppelganger:", log))
+  n_failures <- length(keep(mock_cases, inherits, "mismatch_case"))
+  expect_identical(n_logged, n_failures)
+})

--- a/tests/testthat/test-mismatch.R
+++ b/tests/testthat/test-mismatch.R
@@ -7,7 +7,12 @@ test_that("failures are pushed to log file", {
 
   log <- readLines(file.path(mock_pkg_dir, "tests", "vdiffr.fail"))
 
-  n_logged <- length(grep(">>> Failed doppelganger:", log))
+  n_logged <- length(grep(">> Failed doppelganger:", log))
   n_failures <- length(keep(mock_cases, inherits, "mismatch_case"))
   expect_identical(n_logged, n_failures)
+})
+
+test_that("Verbose outputs svg files", {
+  output <- mock_cases_outputs$output
+  expect_true(grepl(">> Failed doppelganger: myplot", output))
 })

--- a/tests/testthat/test-zzz.R
+++ b/tests/testthat/test-zzz.R
@@ -1,0 +1,16 @@
+
+is_checking <- function() {
+  nzchar(Sys.getenv("R_TESTS"))
+}
+
+# Forward mock-pkg's log in case of failure so we get useful
+# information on Travis
+if (is_checking()) {
+  log <- readLines(file.path(mock_pkg_dir, "tests", "vdiffr.fail"))
+
+  file <- file(file.path("..", "vdiffr.fail"), "a")
+  on.exit(close(file))
+  cxn_meow(file, log)
+
+  invisible(TRUE)
+}


### PR DESCRIPTION
- Adds a `verbose` option to print failing SVG files (original and testcase) during testing.

- When tests are run by R CMD check, a log file is created with all relevant version numbers (freetype, fontconfig, ...) and the SVG contents of failing cases.

You can check the log file from the Travis output as tests are currently failing on the precise build.