### PR TITLE
Added quick-start to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ below for some indications.
 
 ## How to use vdiffr
 
+Getting started with vdiffr is a three step process:
+
+1) Add expectations to by including `expect_doppelganger()` in your test files
+1) Run `manage_cases()` to generate the plots which vdiffr will test against in 
+the future. This will launch a shiny gadget which will ask you to confirm
+that each plot is correct
+1) Run `devtools::test()` to execute the tests as normal
+
 ### Adding expectations
 
 vdiffr integrates with testthat through the `expect_doppelganger()`
@@ -71,14 +79,6 @@ Note that in addition to automatic ggtitles, ggplot2 figures are
 assigned the minimalistic theme `theme_test()` (unless they already
 have been assigned a theme).
 
-
-### Running tests
-
-You can run the tests the usual way, for example with
-`devtools::test()`. New cases for which you just wrote an expectation
-will be skipped. Failed tests will show as an error.
-
-
 ### Managing the tests
 
 When you have added new test cases or detected regressions, you can
@@ -113,6 +113,11 @@ handy to showcase the different graphs offered in your package. You
 can also keep track of how your plots change as you tweak their layout
 and add features by checking the history on Github.
 
+### Running tests
+
+You can run the tests the usual way, for example with
+`devtools::test()`. New cases for which you just wrote an expectation
+will be skipped. Failed tests will show as an error.
 
 ### RStudio integration
 


### PR DESCRIPTION
Thanks for the great package. I just got set up with vdiffr and I ran into some problems figuring out how exactly I should record the plots. I think this was because there the README was missing a kind of high level explainer for the tired and busy, so I read the Manage cases part to be something that you did after tests were successfully running, rather than the thing you need to do to get tests running in the first place. 

This PR adds some additional explication to the README which is what would've made things a bit clearer for me. 