### PR TITLE
Add a quit button to the shiny app user interface

### DIFF
--- a/R/shiny-server.R
+++ b/R/shiny-server.R
@@ -27,6 +27,8 @@ vdiffrServer <- function(cases) {
     validateSingleCase(input, cases)
 
     output$status <- renderStatus(input, cases)
+
+    quitApp(input)
   })
 }
 
@@ -197,5 +199,13 @@ renderStatus <- function(input, reactive_cases) {
     }
 
     list(shiny::br(), paragraph)
+  })
+}
+
+quitApp <- function(input) {
+  shiny::observe({
+    if (input$quit_button > 0) {
+      shiny::stopApp()
+    }
   })
 }

--- a/R/shiny-ui.R
+++ b/R/shiny-ui.R
@@ -21,7 +21,8 @@ sidebarPanel <- function() {
     shiny::uiOutput("case_controls"),
     shiny::actionButton("case_validation_button", "Validate this"),
     shiny::uiOutput("status"),
-    shiny::uiOutput("diff_text_controls")
+    shiny::uiOutput("diff_text_controls"),
+    shiny::actionButton("quit_button", "Quit")
   )
 }
 

--- a/R/shiny-ui.R
+++ b/R/shiny-ui.R
@@ -22,6 +22,7 @@ sidebarPanel <- function() {
     shiny::actionButton("case_validation_button", "Validate this"),
     shiny::uiOutput("status"),
     shiny::uiOutput("diff_text_controls"),
+    shiny::br(),
     shiny::actionButton("quit_button", "Quit")
   )
 }


### PR DESCRIPTION
This PR adds a Quit button to the shiny app user interface that calls `shiny::stopApp()`.

Here is a bit of background to explain the motivation behind it:

I use `vdiffr` to run tests automatically as part of our CI pipeline. (Thank you for the truly excellent package!) The CI runs a Linux-based docker container, and the environment has a specific version of FreeType installed. Since the FreeType version I get on my own laptop via Homebrew is a different one, I run `vdiffr::manage_cases()` (locally) inside the same docker image that the CI uses. That way my validated cases are generated in the same environment as what the CI will use for running tests.

The normal convention of terminating shiny apps with ctrl-c is a bit problematic for this setup, as it is not an interactive session. I would like to be able to terminate the shiny app/R session/docker container from within the web interface, instead of the R console.

This MR therefore adds a simple Quit button to the user interface, and pressing this button will call `shiny::stopApp()`.

This PR currently contains the very minimum required to implement the functionality. I'm happy to append/modify it as needed, be that changes to the UI layout, different business logic, or updates to documentation/tests.

This is related to #24. I agree with that issue that the shiny app should exit when all cases have been validated, and in that scenario a Quit button would be unnecessary. But even if that feature is implemented, a Quit button would allow the user to quit the shiny app from within the web interface even when they do not want to validate all cases.